### PR TITLE
Fix thumbnails over yt-dl

### DIFF
--- a/osc_tethys.lua
+++ b/osc_tethys.lua
@@ -1538,6 +1538,7 @@ function Thumbnailer:prepare_source_path()
         -- This skips ytdl on the sub-calls, making the thumbnailing faster
         -- Works well on YouTube, rest not really tested
         file_path = mp.get_property_native("stream-path")
+        file_path = file_path:gsub(",ytdl_description.+", "")
 
         -- edl:// urls can get LONG. In which case, save the path (URL)
         -- to a temporary file and use that instead.


### PR DESCRIPTION
Thumbnails over yt-dlp broke after the 2021-05-15 builds of MVP.
* https://github.com/mpv-player/mpv/commit/adcf51dccdddc806c7da7172f4e162e69f392370
* https://github.com/mpv-player/mpv/commit/cbb8f534b064f144820435148e516978de08cb30
* https://github.com/mpv-player/mpv/commit/ded36a4470a5970693ee0ceb2f43baa5db470cd3

While this solution is hacky, it works consistently. 
See https://github.com/TheAMM/mpv_thumbnail_script/commit/f32e08658e066ae922e4bcdcf704998ee52569fd


As you're probably aware, the [original](https://github.com/TheAMM/mpv_thumbnail_script) thumbnail script is unfortunately abandonware at this point.
I recently came across [this](https://github.com/marzzzello/mpv_thumbnail_script/tree/master) fork, which has some much needed fixes, including the one you see in this pull request.