### PR TITLE
Add thumbfast integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This theme replaces [the built in `osc.lua`](https://github.com/mpv-player/mpv/b
 
 ![](https://i.imgur.com/cYqWlw5.png)
 
-Local files can show thumbnail previews (using a patched version of [mpv_thumbnail_script](https://github.com/TheAMM/mpv_thumbnail_script)).
+Local files can show thumbnail previews (using [thumbfast](https://github.com/po5/thumbfast) or a patched version of [mpv_thumbnail_script](https://github.com/TheAMM/mpv_thumbnail_script)).
 
 ![](https://i.imgur.com/FegXl3W.png)
 


### PR DESCRIPTION
Closes #22.

This implementation coexists with the thumbnail script currently included in this repo.  
If thumbfast is present, the osc won't try to call TheAMM's thumbnailer.

Regarding your comment of your system not having `socat`, the latest version of thumbfast no longer requires it.  
Hope this is satisfactory.